### PR TITLE
missing param when calling processPost

### DIFF
--- a/index.js
+++ b/index.js
@@ -963,7 +963,7 @@ function processPost(req, resp)
         var ourObjectTemplate = semotus.objectTemplate;
         var remoteSessionId = req.session.id;
         if (typeof(ourObjectTemplate.controller.processPost) == "function") {
-            Q(ourObjectTemplate.controller.processPost(req.body)).then(function (controllerResp) {
+            Q(ourObjectTemplate.controller.processPost(null, req.body)).then(function (controllerResp) {
                 ourObjectTemplate.setSession(remoteSessionId);
                 semotus.save(path, session, req);
                 resp.writeHead(controllerResp.status, controllerResp.headers || {"Content-Type": "text/plain"});


### PR DESCRIPTION
@selsamman check this change out we noticed that in one of the cases the controller processPost function is being called with `(uri, body)` and the other case it is being called with only `(body)` so we passed in `null` to be consistent.