### PR TITLE
Remove AmorphicContext's reset function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 2.4.3
+* Removed reset function from AmorphicContext, which previously was only used for writing tests.
 ## 2.4.2
 * Removed sessionSecret from logs when starting amorphic.
 ## 2.4.1

--- a/index.js
+++ b/index.js
@@ -36,20 +36,6 @@ let AmorphicContext = require('./lib/AmorphicContext');
 // TODO: This should be a default set in Semotus
 Semotus.maxCallTime = 60 * 1000; // Max time for call interlock
 
-// TODO: Remove this - this is just to set the default config options
-// TODO: At a minimum change our tests to not expect a promise back and we can eliminate this function.
-/**
- * This function exists to reset AmorphicContext to the default options.
- *  It is only used by our tests.  Once our tests have been updated to properly stub
- *  AmorphicContext out this should be removed.
- *
- * @returns {Promise<Boolean>} A promise that resolves to true.
- */
-function reset() {
-    AmorphicContext.reset();
-    return Bluebird.resolve(true);
-}
-
 // TODO: Figure out what this does
 // Typescript standard extends helper
 let __extends;
@@ -134,7 +120,6 @@ function Bindable (Base) {
 let toExport = {
     getTemplates: getTemplates,
     listen: listen,
-    reset: reset,
     Remoteable: Remoteable,
 	Bindable: Bindable,
     Persistable: Persistor.Persistable,

--- a/lib/AmorphicContext.js
+++ b/lib/AmorphicContext.js
@@ -14,31 +14,6 @@ let applicationSource = {};
 let applicationSourceMap = {};
 let applicationTSController = {};
 
-/**
- * This function exists to reset AmorphicContext to the default options.
- *  It is only used by our tests.  Once our tests have been updated to properly stub
- *  AmorphicContext out this should be removed.
- */
-function reset() {
-    if (appContext.connectServer) {
-        appContext.connectServer.close();
-    }
-
-    appContext.connectServer = undefined;
-    applicationConfig = {};
-    applicationSource = {};
-    applicationSourceMap = {};
-    applicationPersistorProps = {};
-    applicationTSController = {};
-
-    amorphicOptions = {
-        conflictMode: 'soft',
-        compressSession: false,
-        compressXHR: true,
-        sourceMode: 'debug'
-    };
-}
-
 module.exports = {
     amorphicOptions: amorphicOptions,
     appContext: appContext,
@@ -46,6 +21,5 @@ module.exports = {
     applicationPersistorProps: applicationPersistorProps,
     applicationSource: applicationSource,
     applicationSourceMap: applicationSourceMap,
-    applicationTSController: applicationTSController,
-    reset: reset
+    applicationTSController: applicationTSController
 };

--- a/lib/buildStartUpParams.js
+++ b/lib/buildStartUpParams.js
@@ -2,7 +2,6 @@
 
 let AmorphicContext = require('./AmorphicContext');
 
-// TODO: Rename to buildStartUpParams.
 // TODO: Audit where these get used.
 /**
  * Purpose unknown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amorphic",
-  "version": "2.4.0",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amorphic",
   "description": "Front to back isomorphic framework for developing applications with node.js and mongoDB",
   "homepage": "https://github.com/selsamman/amorphic",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "amorphic-bindster": "2.0.*",
     "bluebird": "3.5.1",

--- a/test/V2/amorphic.js
+++ b/test/V2/amorphic.js
@@ -3,12 +3,14 @@ var request = require('request');
 var axios = require('axios');
 var path = require('path');
 
+var amorphicContext = require('../../lib/AmorphicContext');
 var serverAmorphic = require('../../index.js');
 
 function afterEachDescribe(done) {
-    serverAmorphic.reset().then(function () {
-        done();
-    });
+    if(amorphicContext.appContext.connectServer){
+        amorphicContext.appContext.connectServer.close();
+    }
+    done();
 }
 function beforeEachDescribe(done, appName, createControllerFor, sourceMode) {
     process.env.createControllerFor = createControllerFor;

--- a/test/daemon/daemon.js
+++ b/test/daemon/daemon.js
@@ -5,6 +5,7 @@ let amorphic = require('../../index.js');
 let axios = require('axios');
 let fs = require('fs');
 let path = require('path');
+let amorphicContext = require('../../lib/AmorphicContext');
 
 describe('Run amorphic as a deamon', function() {
 
@@ -71,9 +72,9 @@ describe('Run amorphic as a deamon', function() {
 
     after(function(done) {
         // Clean up server
-        amorphic.reset()
-            .then(function() {
-                done();
-            });
+        if(amorphicContext.appContext.connectServer){
+            amorphicContext.appContext.connectServer.close();
+        }
+        done();
     });
 });

--- a/test/daemon_auto/daemon_auto.js
+++ b/test/daemon_auto/daemon_auto.js
@@ -5,6 +5,7 @@ let amorphic = require('../../index.js');
 let axios = require('axios');
 let fs = require('fs');
 let path = require('path');
+let amorphicContext = require('../../lib/AmorphicContext');
 
 describe('Run amorphic as a deamon with template mode "auto"', function() {
     before(function(done) {
@@ -74,9 +75,9 @@ describe('Run amorphic as a deamon with template mode "auto"', function() {
 
     after(function(done) {
         // Clean up server
-        amorphic.reset()
-            .then(function() {
-                done();
-            });
+        if(amorphicContext.appContext.connectServer){
+            amorphicContext.appContext.connectServer.close();
+        }
+        done();
     });
 });

--- a/test/example/index.js
+++ b/test/example/index.js
@@ -6,6 +6,7 @@ let sinon = require('sinon');
 let axios = require('axios');
 let fs = require('fs');
 let path = require('path');
+let amorphicContext = require('../../lib/AmorphicContext');
 
 describe('Setup amorphic', function() {
     let server;
@@ -28,7 +29,8 @@ describe('Setup amorphic', function() {
 
     after(function() {
         // Clean up server
-        // server.close();
-        return serverAmorphic.reset();
+        if(amorphicContext.appContext.connectServer){
+            amorphicContext.appContext.connectServer.close();
+        }
     });
 });

--- a/test/postgres/amorphic.js
+++ b/test/postgres/amorphic.js
@@ -40,14 +40,16 @@ var modelRequires;
 var controllerRequires;
 var Controller;
 var serverAmorphic = require('../../index.js');
+var amorphicContext = require('../../lib/AmorphicContext');
 
 // Fire up amrophic as the client
 require('../../client.js');
 
 function afterEachDescribe(done) {
-    serverAmorphic.reset().then(function () {
-        done();
-    });
+    if(amorphicContext.appContext.connectServer){
+        amorphicContext.appContext.connectServer.close();
+    }
+    done();
 }
 function beforeEachDescribe(done, appName, createControllerFor, sourceMode) {
     process.env.createControllerFor = createControllerFor;


### PR DESCRIPTION
Scope / Commits:
1) Cleanup an irrelevant TODO
2) Remove AmorphicContext's reset() function that was only used in functional tests within Amorphic.

Description:
We are able to remove the `reset()` function from `AmorphicContext` because previously it was only being used to close the server connection that was initiated by `amorphic.listen()` whenever doing cleanup for test(s).

The new way of closing the connection would be to require `AmorphicContext` to get a handle on the appContext where we need it to be closed, this would actually give you the same instance of AmorphicContext because these tests files are within the same project. Node actually caches the requests for the same module.
Note: This is not the case when you have two npm modules that require the same module as a dependency. They would not share the same instance and there would be two copies.
Reference: http://justjs.com/posts/singletons-in-node-js-modules-cannot-be-trusted-or-why-you-can-t-just-do-var-foo-require-baz-init


![image](https://user-images.githubusercontent.com/3759626/36747192-579a319c-1bc2-11e8-8bb8-9dd399fc4ff1.png)
