### PR TITLE
clientInit.js can be used to bootstrap amorphic client; package.json changes

### DIFF
--- a/clientInit.js
+++ b/clientInit.js
@@ -12,28 +12,20 @@ function __bindController (newController, sessionExpiration) {
     controller = newController;
     if (firstTimeLoad) {
         firstTimeLoad = false;
-        if (typeof(controller.clientInit) === 'function') {
-            controller.clientInit(sessionExpiration);
-        }
     }
-    else {
-        if (typeof(controller.clientInit) === 'function') {
-            controller.clientInit(sessionExpiration);
-        }
-        controller.refresh(1);
+    if (typeof(controller.clientInit) === 'function') {
+        controller.clientInit(sessionExpiration);
     }
 }
 
 // Rerender after xhr request received
 function __refresh (hadChanges) {
-    controller.refresh(1, hadChanges);
 }
 
 // When a new version is detected pop up "about to be refreshed" and
 // then reload the document after 5 seconds.
 function __reload () {
     controller.amorphicStatus = 'reloading';
-    controller.refresh(1);
     setTimeout(function reload () {
         document.location.reload(true);
     }, 3000);

--- a/clientInit.js
+++ b/clientInit.js
@@ -1,0 +1,48 @@
+const __controllerTemplate = 'Controller';
+const __appVersion = __ver || 0;
+
+var controller = typeof(controller) === 'undefined' ? null : controller;
+var firstTimeLoad = typeof(firstTimeLoad) === 'undefined';
+
+// Establish a new session whether first time or because of expiry / server restart
+function __bindController (newController, sessionExpiration) {
+    if (controller && typeof(controller.shutdown) === 'function') {
+        controller.shutdown();
+    }
+    controller = newController;
+    if (firstTimeLoad) {
+        firstTimeLoad = false;
+        if (typeof(controller.clientInit) === 'function') {
+            controller.clientInit(sessionExpiration);
+        }
+    }
+    else {
+        if (typeof(controller.clientInit) === 'function') {
+            controller.clientInit(sessionExpiration);
+        }
+        controller.refresh(1);
+    }
+}
+
+// Rerender after xhr request received
+function __refresh (hadChanges) {
+    controller.refresh(1, hadChanges);
+}
+
+// When a new version is detected pop up "about to be refreshed" and
+// then reload the document after 5 seconds.
+function __reload () {
+    controller.amorphicStatus = 'reloading';
+    controller.refresh(1);
+    setTimeout(function reload () {
+        document.location.reload(true);
+    }, 3000);
+}
+
+// If communication lost pop up dialog
+function __offline () {
+    controller.amorphicStatus = 'offline';
+}
+
+// Create amorphic client session
+amorphic.establishClientSession(__controllerTemplate, __appVersion, __bindController, __refresh, __reload, __offline);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amorphic",
-  "version": "2.4.0",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2655,15 +2655,6 @@
         "uuid": "3.1.0"
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.4.1"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2680,6 +2671,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
       }
     },
     "resolve": {
@@ -2942,14 +2942,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2958,6 +2950,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amorphic",
   "description": "Front to back isomorphic framework for developing applications with node.js and mongoDB",
   "homepage": "https://github.com/selsamman/amorphic",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "amorphic-bindster": "2.0.*",
     "bluebird": "3.5.1",


### PR DESCRIPTION
The scope of this PR is to set the groundwork for eliminating the dependency of amorphic to bindster.
However, the amorphic client was being initialized inside the bindster-amorphic.js which is inside the amorphic-bindster module. Thus, we 're importing this file within index.html and using a hacky script to override the bindster methods:

<script> function Bindster() {} Bindster.prototype.start = function () {} Bindster.prototype.setModel = function() {} Bindster.prototype.setController = function() {} </script>
I created a new file called clientInit.js at the root of the amorphic project.
Importing just this file is enough to initialize the amorphic client (the establishClientSession is invoked at the very end)
I went through some refactoring of that code as well. All of the bindster related code is removed and another variable is used instead (firstTimeLoad). Used consts were posssible, changed a log entry and pulled all the function arguments outside.

** A future PR could also stop serving bindster through amorphic all together. For this to happen, anything that uses amorphic and relies on that dependency to also use bindster should import bindster 'itself'.