### PR TITLE
Amorphic client bootstrap - update on Lysandros' mr

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 var OFF = 0, WARN = 1, ERROR = 2;
 
 module.exports = exports = {
+    "globals": {
+      "amorphic": true  
+    },
     
     "env": {
         "node": true,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+
+## 2.4.8
+* Added clientInit.js to allow to remove the dependency for Bindster in Amorphic. See the pull request notes for more details (https://github.com/selsamman/amorphic/pull/55).
 ## 2.4.7
 * Fixed error logging for checking the application list.
 ## 2.4.6

--- a/clientInit.js
+++ b/clientInit.js
@@ -2,7 +2,6 @@ const __controllerTemplate = 'Controller';
 const __appVersion = __ver || 0;
 
 var controller = typeof(controller) === 'undefined' ? null : controller;
-var firstTimeLoad = typeof(firstTimeLoad) === 'undefined';
 
 // Establish a new session whether first time or because of expiry / server restart
 function __bindController (newController, sessionExpiration) {
@@ -10,9 +9,6 @@ function __bindController (newController, sessionExpiration) {
         controller.shutdown();
     }
     controller = newController;
-    if (firstTimeLoad) {
-        firstTimeLoad = false;
-    }
     if (typeof(controller.clientInit) === 'function') {
         controller.clientInit(sessionExpiration);
     }

--- a/clientInit.js
+++ b/clientInit.js
@@ -12,28 +12,20 @@ function __bindController (newController, sessionExpiration) {
     controller = newController;
     if (firstTimeLoad) {
         firstTimeLoad = false;
-        if (typeof(controller.clientInit) === 'function') {
-            controller.clientInit(sessionExpiration);
-        }
     }
-    else {
-        if (typeof(controller.clientInit) === 'function') {
-            controller.clientInit(sessionExpiration);
-        }
-        controller.refresh(1);
+    if (typeof(controller.clientInit) === 'function') {
+        controller.clientInit(sessionExpiration);
     }
 }
 
 // Rerender after xhr request received
 function __refresh (hadChanges) {
-    controller.refresh(1, hadChanges);
 }
 
 // When a new version is detected pop up "about to be refreshed" and
 // then reload the document after 5 seconds.
 function __reload () {
     controller.amorphicStatus = 'reloading';
-    controller.refresh(1);
     setTimeout(function reload () {
         document.location.reload(true);
     }, 3000);

--- a/clientInit.js
+++ b/clientInit.js
@@ -1,0 +1,48 @@
+const __controllerTemplate = 'Controller';
+const __appVersion = __ver || 0;
+
+var controller = typeof(controller) === 'undefined' ? null : controller;
+var firstTimeLoad = typeof(firstTimeLoad) === 'undefined';
+
+// Establish a new session whether first time or because of expiry / server restart
+function __bindController (newController, sessionExpiration) {
+    if (controller && typeof(controller.shutdown) === 'function') {
+        controller.shutdown();
+    }
+    controller = newController;
+    if (firstTimeLoad) {
+        firstTimeLoad = false;
+        if (typeof(controller.clientInit) === 'function') {
+            controller.clientInit(sessionExpiration);
+        }
+    }
+    else {
+        if (typeof(controller.clientInit) === 'function') {
+            controller.clientInit(sessionExpiration);
+        }
+        controller.refresh(1);
+    }
+}
+
+// Rerender after xhr request received
+function __refresh (hadChanges) {
+    controller.refresh(1, hadChanges);
+}
+
+// When a new version is detected pop up "about to be refreshed" and
+// then reload the document after 5 seconds.
+function __reload () {
+    controller.amorphicStatus = 'reloading';
+    controller.refresh(1);
+    setTimeout(function reload () {
+        document.location.reload(true);
+    }, 3000);
+}
+
+// If communication lost pop up dialog
+function __offline () {
+    controller.amorphicStatus = 'offline';
+}
+
+// Create amorphic client session
+amorphic.establishClientSession(__controllerTemplate, __appVersion, __bindController, __refresh, __reload, __offline);

--- a/clientInit.js
+++ b/clientInit.js
@@ -1,5 +1,7 @@
+'use strict';
+
 const __controllerTemplate = 'Controller';
-const __appVersion = __ver || 0;
+const __appVersion = 0;
 
 var controller = typeof(controller) === 'undefined' ? null : controller;
 
@@ -15,8 +17,7 @@ function __bindController (newController, sessionExpiration) {
 }
 
 // Rerender after xhr request received
-function __refresh (hadChanges) {
-}
+function __refresh () {}
 
 // When a new version is detected pop up "about to be refreshed" and
 // then reload the document after 5 seconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amorphic",
-  "version": "2.4.0",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2655,15 +2655,6 @@
         "uuid": "3.1.0"
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.4.1"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2680,6 +2671,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
       }
     },
     "resolve": {
@@ -2942,14 +2942,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2958,6 +2950,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amorphic",
   "description": "Front to back isomorphic framework for developing applications with node.js and mongoDB",
   "homepage": "https://github.com/selsamman/amorphic",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "amorphic-bindster": "2.0.*",
     "bluebird": "3.5.1",


### PR DESCRIPTION
From lysandros' mr

> The scope of this PR is to set the groundwork for eliminating the dependency of amorphic to bindster.
In current applications we may not need to use Bindster anymore.
However, the amorphic client was being initialized inside the bindster-amorphic.js which is inside the amorphic-bindster module. Thus, in those apps we're importing this file within index.html and using a hacky script to override the bindster methods:

> <script> function Bindster() {} Bindster.prototype.start = function () {} Bindster.prototype.setModel = function() {} Bindster.prototype.setController = function() {} </script>
> I created a new file called clientInit.js at the root of the amorphic project.
Importing just this file is enough to initialize the amorphic client (the establishClientSession is invoked at the very end)
> I went through some refactoring of that code as well. All of the bindster related code is removed and another variable is used instead (firstTimeLoad). Used consts were posssible, changed a log entry and pulled all the function arguments outside.
> This change was tested in current applications (their index.html was modified to import the new file and the hacky script was removed).
> ** A future PR could also stop serving bindster through amorphic all together. For this to happen, anything that uses amorphic and relies on that dependency to also use bindster should import bindster 'itself'.

I've retested the change and also updated the package.json and package-lock.json

On top of that these are the new changes you will have to make in your app in order to use this approach.

Whereas before if you had a non-bindster application using a different UI framework (such as angular) you might have to add these script tags to you index.html
`  <script>
        function Bindster() {}
        Bindster.prototype.start = function () {}
        Bindster.prototype.setModel = function() {}
        Bindster.prototype.setController = function() {}
    </script>`

and 
`<script src="/bindster/bindster-amorphic.js"></script>`

Now you can delete the both blocks. Instead of the latter block which includes bindster-amorphic, you should replace that with this instead
`<script src="/amorphic/clientInit.js"></script>`
